### PR TITLE
Fix syntax deprecated in PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mariodevment/monolog-cascade",
+    "name": "opok/monolog-cascade",
     "license": "MIT",
     "type": "library",
     "description": "Monolog extension to configure multiple loggers in the blink of an eye and access them from anywhere",
@@ -40,7 +40,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.5.x-dev"
+            "dev-master": "0.6.x-dev"
         }
     }
 }

--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -51,7 +51,7 @@ class Json extends FileLoaderAbstract
     {
         return (
             !empty($string) &&
-            ($string{0} === '[' || $string{0} === '{')
+            ($string[0] === '[' || $string[0] === '{')
         );
     }
 


### PR DESCRIPTION
cherry picked commit b515bbc1a1a96efc967ac8836585e0e347fbb9a0 from the original theorchard/monolog-cascade

original PR https://github.com/theorchard/monolog-cascade/pull/94